### PR TITLE
Refactor namespaces and enhance EnvironmentProvider

### DIFF
--- a/src/ComicReader.SDK/ComicReader.SDK.csproj
+++ b/src/ComicReader.SDK/ComicReader.SDK.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="PDFium.x64" Version="4648.0.0" />
     <PackageReference Include="PDFium.x86" Version="4648.0.0" />
     <PackageReference Include="PdfiumViewer.Updated" Version="2.14.4" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ComicReader.SDK/Common/AppEnvironment/DeviceInformationHelper.cs
+++ b/src/ComicReader.SDK/Common/AppEnvironment/DeviceInformationHelper.cs
@@ -6,16 +6,15 @@
 
 #nullable disable
 
-using System;
 using System.Management;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
 using Microsoft.Win32;
 
-namespace ComicReader.Common.AppEnvironment;
+namespace ComicReader.SDK.Common.AppEnvironment;
 
-class DeviceInformationHelper
+internal class DeviceInformationHelper
 {
     public static string DefaultSystemManufacturer = "System manufacturer";
     public static string DefaultSystemProductName = "System Product Name";
@@ -38,7 +37,7 @@ class DeviceInformationHelper
             if (managementObjectEnumerator.MoveNext())
             {
                 string text = (string)managementObjectEnumerator.Current["Model"];
-                return (string.IsNullOrEmpty(text) || DefaultSystemProductName == text) ? null : text;
+                return string.IsNullOrEmpty(text) || DefaultSystemProductName == text ? null : text;
             }
         }
         catch (UnauthorizedAccessException)
@@ -74,7 +73,7 @@ class DeviceInformationHelper
             if (managementObjectEnumerator.MoveNext())
             {
                 string text = (string)managementObjectEnumerator.Current["Manufacturer"];
-                return (string.IsNullOrEmpty(text) || DefaultSystemManufacturer == text) ? null : text;
+                return string.IsNullOrEmpty(text) || DefaultSystemManufacturer == text ? null : text;
             }
         }
         catch (UnauthorizedAccessException)
@@ -113,7 +112,7 @@ class DeviceInformationHelper
         object value5 = registryKey2.GetValue("CurrentVersion", "0.0");
         object value6 = registryKey2.GetValue("CurrentBuild", "0");
         string[] array = registryKey2.GetValue("BuildLabEx")?.ToString().Split('.');
-        string value7 = ((array != null && array.Length >= 2) ? array[1] : "0");
+        string value7 = array != null && array.Length >= 2 ? array[1] : "0";
         return $"{value5}.{value6}.{value7}";
     }
 

--- a/src/ComicReader.SDK/Common/AppEnvironment/EnvironmentProvider.cs
+++ b/src/ComicReader.SDK/Common/AppEnvironment/EnvironmentProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) aicd0. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -10,17 +8,19 @@ using System.Text;
 
 using ComicReader.SDK.Common.DebugTools;
 using ComicReader.SDK.Common.ServiceManagement;
+using ComicReader.SDK.Common.Utils;
 
 using Windows.ApplicationModel;
 using Windows.System.UserProfile;
 
-namespace ComicReader.Common.AppEnvironment;
+namespace ComicReader.SDK.Common.AppEnvironment;
 
-internal class EnvironmentProvider
+public class EnvironmentProvider
 {
     public static EnvironmentProvider Instance = new();
 
     private readonly DateTimeOffset _launchTime;
+    private string _additionalDebugInformation = string.Empty;
 
     private EnvironmentProvider()
     {
@@ -31,17 +31,9 @@ internal class EnvironmentProvider
     /// Initialize the EnvironmentProvider instance. Some fields like launch time
     /// require the static instance to be initialized as soon as possible.
     /// </summary>
-    public void Initialize()
+    public void Initialize(string additionalDebugInformation)
     {
-        // Keep this even if it does nothing, as some logic is performed in the constructor
-    }
-
-    public Dictionary<string, string> GetEnvironmentTags()
-    {
-        Dictionary<string, string> tags = [];
-        tags["version-name"] = GetVersionName();
-        tags["portable"] = IsPortable().ToString();
-        return tags;
+        _additionalDebugInformation = additionalDebugInformation;
     }
 
     public void AppendDebugText(StringBuilder sb)
@@ -64,15 +56,32 @@ internal class EnvironmentProvider
         sb.SafeAppend("Launch time", () => GetLaunchTime());
         sb.SafeAppend("Awake time", () => GetAwakeTime());
 
-        string additionalInfo = Properties.AdditionalDebugInformation;
-        if (additionalInfo.Length > 0)
+        if (_additionalDebugInformation.Length > 0)
         {
-            sb.Append(additionalInfo);
+            sb.Append(_additionalDebugInformation);
             sb.Append('\n');
         }
     }
 
-    public string GetVersionName()
+    public DateTimeOffset GetLaunchTime()
+    {
+        return _launchTime;
+    }
+
+    public TimeSpan GetAwakeTime()
+    {
+        return DateTimeOffset.Now - _launchTime;
+    }
+
+    public static Dictionary<string, string> GetEnvironmentTags()
+    {
+        Dictionary<string, string> tags = [];
+        tags["version-name"] = GetVersionName();
+        tags["portable"] = IsPortable().ToString();
+        return tags;
+    }
+
+    public static string GetVersionName()
     {
         if (IsPortable())
         {
@@ -90,19 +99,9 @@ internal class EnvironmentProvider
         }
     }
 
-    public string GetCurrentSystemLanguage()
+    public static string GetCurrentSystemLanguage()
     {
         return GlobalizationPreferences.Languages[0];
-    }
-
-    public DateTimeOffset GetLaunchTime()
-    {
-        return _launchTime;
-    }
-
-    public TimeSpan GetAwakeTime()
-    {
-        return DateTimeOffset.Now - _launchTime;
     }
 
     public static bool IsPortable()

--- a/src/ComicReader.SDK/Common/AppEnvironment/ManagementClassFactory.cs
+++ b/src/ComicReader.SDK/Common/AppEnvironment/ManagementClassFactory.cs
@@ -8,7 +8,7 @@
 
 using System.Management;
 
-namespace ComicReader.Common.AppEnvironment;
+namespace ComicReader.SDK.Common.AppEnvironment;
 
 internal class ManagementClassFactory
 {

--- a/src/ComicReader.SDK/Common/AppEnvironment/WindowsHelper.cs
+++ b/src/ComicReader.SDK/Common/AppEnvironment/WindowsHelper.cs
@@ -6,15 +6,12 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using System.Reflection;
 
-using ComicReader.Common.Native;
+using ComicReader.SDK.Common.Native;
 
-namespace ComicReader.Common.AppEnvironment;
+namespace ComicReader.SDK.Common.AppEnvironment;
 
 internal static class WindowsHelper
 {
@@ -26,7 +23,7 @@ internal static class WindowsHelper
 
     private const uint WINEVENT_OUTOFCONTEXT = 0u;
 
-    private static readonly IDictionary<NativeModels.WinEventDelegate, IntPtr> _hooks;
+    private static readonly IDictionary<NativeModels.WinEventDelegate, nint> _hooks;
 
     private const int DESKTOPVERTRES = 117;
 
@@ -47,7 +44,7 @@ internal static class WindowsHelper
         add
         {
             uint id = (uint)Environment.ProcessId;
-            IntPtr value2 = NativeMethods.SetWinEventHook(22u, 23u, IntPtr.Zero, value, id, 0u, 0u);
+            nint value2 = NativeMethods.SetWinEventHook(22u, 23u, nint.Zero, value, id, 0u, 0u);
             _hooks.Add(value, value2);
         }
         remove
@@ -63,7 +60,7 @@ internal static class WindowsHelper
     {
         try
         {
-            return Assembly.GetEntryAssembly().GetReferencedAssemblies().Any((AssemblyName referencedAssembly) => referencedAssembly.Name == "Windows.UI.Xaml");
+            return Assembly.GetEntryAssembly().GetReferencedAssemblies().Any((referencedAssembly) => referencedAssembly.Name == "Windows.UI.Xaml");
         }
         catch (Exception)
         {
@@ -76,7 +73,7 @@ internal static class WindowsHelper
     {
         try
         {
-            return Assembly.GetEntryAssembly().GetReferencedAssemblies().Any((AssemblyName referencedAssembly) => referencedAssembly.Name == "Microsoft.UI.Xaml" || referencedAssembly.Name == "Microsoft.WinUI");
+            return Assembly.GetEntryAssembly().GetReferencedAssemblies().Any((referencedAssembly) => referencedAssembly.Name == "Microsoft.UI.Xaml" || referencedAssembly.Name == "Microsoft.WinUI");
         }
         catch (Exception)
         {
@@ -87,15 +84,15 @@ internal static class WindowsHelper
 
     public static void GetScreenSize(out int width, out int height)
     {
-        using var graphics = Graphics.FromHwnd(IntPtr.Zero);
-        IntPtr hdc = graphics.GetHdc();
+        using var graphics = Graphics.FromHwnd(nint.Zero);
+        nint hdc = graphics.GetHdc();
         width = NativeMethods.GetDeviceCaps(hdc, 118);
         height = NativeMethods.GetDeviceCaps(hdc, 117);
     }
 
     static WindowsHelper()
     {
-        _hooks = new Dictionary<NativeModels.WinEventDelegate, IntPtr>();
+        _hooks = new Dictionary<NativeModels.WinEventDelegate, nint>();
         try
         {
             Assembly assembly = GetAssembly("PresentationFramework");
@@ -117,7 +114,7 @@ internal static class WindowsHelper
 
     private static Assembly GetAssembly(string name)
     {
-        return AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault((Assembly assembly) => assembly.GetName().Name == name);
+        return AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault((assembly) => assembly.GetName().Name == name);
     }
 
     private static Rectangle WindowsRectToRectangle(dynamic windowsRect)

--- a/src/ComicReader.SDK/Common/DebugTools/SentryManager.cs
+++ b/src/ComicReader.SDK/Common/DebugTools/SentryManager.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) aicd0. All rights reserved.
 // Licensed under the MIT License.
 
+using ComicReader.SDK.Common.AppEnvironment;
+using ComicReader.SDK.Common.Storage;
+
 namespace ComicReader.SDK.Common.DebugTools;
 
 public static class SentryManager
@@ -22,7 +25,10 @@ public static class SentryManager
         SentrySdk.Init(o =>
         {
             o.AutoSessionTracking = true;
+            o.CacheDirectoryPath = StorageLocation.GetLocalCacheFolderPath();
+            o.Distribution = EnvironmentProvider.IsPortable() ? "Portable" : "Packaged";
             o.Dsn = dsn;
+            o.Release = EnvironmentProvider.GetVersionName();
 
             foreach (KeyValuePair<string, string> tag in tags)
             {

--- a/src/ComicReader.SDK/Common/Native/NativeMethods.cs
+++ b/src/ComicReader.SDK/Common/Native/NativeMethods.cs
@@ -1,18 +1,17 @@
 // Copyright (c) aicd0. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Runtime.InteropServices;
 
 using Microsoft.Win32.SafeHandles;
 
-namespace ComicReader.Common.Native;
+namespace ComicReader.SDK.Common.Native;
 
-internal class NativeMethods
+public class NativeMethods
 {
     // https://docs.microsoft.com/en-us/windows/win32/api/fileapifromapp/nf-fileapifromapp-createfilefromappw
     [DllImport("api-ms-win-core-file-fromapp-l1-1-0.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    internal static extern SafeFileHandle CreateFileFromApp(string lpFileName,
+    public static extern SafeFileHandle CreateFileFromApp(string lpFileName,
         int dwDesiredAccess,
         int dwShareMode,
         nint lpSecurityAttributes,
@@ -23,7 +22,7 @@ internal class NativeMethods
 
     // https://docs.microsoft.com/en-us/windows/win32/api/fileapifromapp/nf-fileapifromapp-findfirstfileexfromappw
     [DllImport("api-ms-win-core-file-fromapp-l1-1-0.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    internal static extern nint FindFirstFileExFromApp(
+    public static extern nint FindFirstFileExFromApp(
         string lpFileName,
         NativeModels.FindExInfoLevel fInfoLevelId,
         out NativeModels.Win32FindData lpFindFileData,
@@ -33,29 +32,29 @@ internal class NativeMethods
     );
 
     [DllImport("api-ms-win-core-file-l1-1-0.dll", CharSet = CharSet.Unicode)]
-    internal static extern bool FindNextFile(
+    public static extern bool FindNextFile(
         nint hFindFile,
         out NativeModels.Win32FindData lpFindFileData
     );
 
     [DllImport("api-ms-win-core-file-l1-1-0.dll")]
-    internal static extern bool FindClose(nint hFindFile);
+    public static extern bool FindClose(nint hFindFile);
 
     [DllImport("Shcore.dll", SetLastError = true)]
-    internal static extern int GetDpiForMonitor(nint hmonitor, NativeModels.MonitorDPIType dpiType, out uint dpiX, out uint dpiY);
+    public static extern int GetDpiForMonitor(nint hmonitor, NativeModels.MonitorDPIType dpiType, out uint dpiX, out uint dpiY);
 
     [DllImport("user32.dll")]
-    internal static extern bool GetWindowPlacement(nint hWnd, out NativeModels.WindowPlacement lpwndpl);
+    public static extern bool GetWindowPlacement(nint hWnd, out NativeModels.WindowPlacement lpwndpl);
 
     [DllImport("user32.dll")]
-    internal static extern bool SetWindowPlacement(nint hWnd, [In] ref NativeModels.WindowPlacement lpwndpl);
+    public static extern bool SetWindowPlacement(nint hWnd, [In] ref NativeModels.WindowPlacement lpwndpl);
 
     [DllImport("user32.dll")]
-    internal static extern IntPtr SetWinEventHook(uint eventMin, uint eventMax, IntPtr eventHookAssemblyHandle, NativeModels.WinEventDelegate eventHookHandle, uint processId, uint threadId, uint dwFlags);
+    public static extern nint SetWinEventHook(uint eventMin, uint eventMax, nint eventHookAssemblyHandle, NativeModels.WinEventDelegate eventHookHandle, uint processId, uint threadId, uint dwFlags);
 
     [DllImport("user32.dll")]
-    internal static extern bool UnhookWinEvent(IntPtr hWinEventHook);
+    public static extern bool UnhookWinEvent(nint hWinEventHook);
 
     [DllImport("gdi32.dll")]
-    internal static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
+    public static extern int GetDeviceCaps(nint hdc, int nIndex);
 }

--- a/src/ComicReader.SDK/Common/Native/NativeModels.cs
+++ b/src/ComicReader.SDK/Common/Native/NativeModels.cs
@@ -1,22 +1,21 @@
 // Copyright (c) aicd0. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Runtime.InteropServices;
 
-namespace ComicReader.Common.Native;
+namespace ComicReader.SDK.Common.Native;
 
-internal class NativeModels
+public class NativeModels
 {
     // https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ne-minwinbase-findex_info_levels
-    internal enum FindExInfoLevel
+    public enum FindExInfoLevel
     {
         FindExInfoStandard = 0,
         FindExInfoBasic = 1
     }
 
     // https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ne-minwinbase-findex_search_ops
-    internal enum FIndexSearchOps
+    public enum FIndexSearchOps
     {
         FindExSearchNameMatch = 0,
         FindExSearchLimitToDirectories = 1,
@@ -25,7 +24,7 @@ internal class NativeModels
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-    internal struct Win32FindData
+    public struct Win32FindData
     {
         public uint dwFileAttributes;
         public System.Runtime.InteropServices.ComTypes.FILETIME ftCreationTime;
@@ -41,7 +40,7 @@ internal class NativeModels
         public string cAlternateFileName;
     }
 
-    internal enum MonitorDPIType : int
+    public enum MonitorDPIType : int
     {
         MDT_Effective_DPI = 0,
         MDT_Angular_DPI = 1,
@@ -49,7 +48,7 @@ internal class NativeModels
         MDT_Default = MDT_Effective_DPI
     }
 
-    internal enum ShowWindowCommands : int
+    public enum ShowWindowCommands : int
     {
         Hide = 0,
         Normal = 1,
@@ -59,7 +58,7 @@ internal class NativeModels
 
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    internal struct WindowPlacement
+    public struct WindowPlacement
     {
         public int length { get; set; }
         public int flags { get; set; }
@@ -69,5 +68,5 @@ internal class NativeModels
         public System.Drawing.Rectangle rcNormalPosition { get; set; }
     }
 
-    internal delegate void WinEventDelegate(IntPtr winEventHookHandle, uint eventType, IntPtr windowHandle, int objectId, int childId, uint eventThreadId, uint eventTimeInMilliseconds);
+    public delegate void WinEventDelegate(nint winEventHookHandle, uint eventType, nint windowHandle, int objectId, int childId, uint eventThreadId, uint eventTimeInMilliseconds);
 }

--- a/src/ComicReader.SDK/Common/Utils/Extensions.cs
+++ b/src/ComicReader.SDK/Common/Utils/Extensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) aicd0. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text;
+
+namespace ComicReader.SDK.Common.Utils;
+
+internal static class Extensions
+{
+    public static void SafeAppend(this StringBuilder sb, string category, Func<object> func)
+    {
+        string value;
+        try
+        {
+            value = func()?.ToString() ?? "[null]";
+        }
+        catch (Exception)
+        {
+            return;
+        }
+        sb.Append(category);
+        sb.Append(": ");
+        sb.Append(value);
+        sb.Append('\n');
+    }
+}

--- a/src/ComicReader/App.xaml.cs
+++ b/src/ComicReader/App.xaml.cs
@@ -5,12 +5,12 @@ using System;
 using System.Threading.Tasks;
 
 using ComicReader.Common;
-using ComicReader.Common.AppEnvironment;
 using ComicReader.Common.Services;
 using ComicReader.Data;
 using ComicReader.Data.Legacy;
 using ComicReader.Data.Models;
 using ComicReader.Data.Models.Comic;
+using ComicReader.SDK.Common.AppEnvironment;
 using ComicReader.SDK.Common.DebugTools;
 using ComicReader.SDK.Common.ServiceManagement;
 
@@ -93,10 +93,10 @@ public partial class App : Application
         ServiceManager.RegisterService<IDebugService>(new DebugService());
 
         // Initialize environment information
-        EnvironmentProvider.Instance.Initialize();
+        EnvironmentProvider.Instance.Initialize(Properties.AdditionalDebugInformation);
 
         // Initialize Sentry
-        SentryManager.Initialize(Properties.SentryDsn, EnvironmentProvider.Instance.GetEnvironmentTags());
+        SentryManager.Initialize(Properties.SentryDsn, EnvironmentProvider.GetEnvironmentTags());
 
         // Initialize app language
         InitializeAppLanguage();
@@ -128,7 +128,7 @@ public partial class App : Application
             string languageTag = AppSettingsModel.Instance.GetModel().Language;
             if (string.IsNullOrEmpty(languageTag))
             {
-                languageTag = EnvironmentProvider.Instance.GetCurrentSystemLanguage();
+                languageTag = EnvironmentProvider.GetCurrentSystemLanguage();
             }
             ApplicationLanguages.PrimaryLanguageOverride = languageTag;
         }

--- a/src/ComicReader/Common/DisplayUtils.cs
+++ b/src/ComicReader/Common/DisplayUtils.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Drawing;
 
-using ComicReader.Common.Native;
 using ComicReader.SDK.Common.DebugTools;
+using ComicReader.SDK.Common.Native;
 
 using Microsoft.UI;
 using Microsoft.UI.Windowing;

--- a/src/ComicReader/Common/Services/ApplicationService.cs
+++ b/src/ComicReader/Common/Services/ApplicationService.cs
@@ -3,7 +3,7 @@
 
 using System.Text;
 
-using ComicReader.Common.AppEnvironment;
+using ComicReader.SDK.Common.AppEnvironment;
 using ComicReader.SDK.Common.ServiceManagement;
 
 namespace ComicReader.Common.Services;

--- a/src/ComicReader/Common/Win32IO.cs
+++ b/src/ComicReader/Common/Win32IO.cs
@@ -7,8 +7,8 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
-using ComicReader.Common.Native;
 using ComicReader.SDK.Common.DebugTools;
+using ComicReader.SDK.Common.Native;
 
 using Microsoft.Win32.SafeHandles;
 

--- a/src/ComicReader/MainWindow.xaml.cs
+++ b/src/ComicReader/MainWindow.xaml.cs
@@ -9,11 +9,11 @@ using System.Text.Json;
 using System.Threading.Tasks;
 
 using ComicReader.Common;
-using ComicReader.Common.Native;
 using ComicReader.Data.Models;
 using ComicReader.Data.Models.Comic;
 using ComicReader.Helpers.Navigation;
 using ComicReader.SDK.Common.KVStorage;
+using ComicReader.SDK.Common.Native;
 using ComicReader.Views.Main;
 
 using Microsoft.UI;

--- a/src/ComicReader/Views/Settings/SettingPage.xaml.cs
+++ b/src/ComicReader/Views/Settings/SettingPage.xaml.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Text;
 
 using ComicReader.Common;
-using ComicReader.Common.AppEnvironment;
 using ComicReader.Common.BaseUI;
 using ComicReader.Common.Threading;
 using ComicReader.Data;
@@ -15,6 +14,7 @@ using ComicReader.Data.Models;
 using ComicReader.Data.Models.Comic;
 using ComicReader.Data.Tables;
 using ComicReader.Helpers.Navigation;
+using ComicReader.SDK.Common.AppEnvironment;
 using ComicReader.SDK.Data.SqlHelpers;
 using ComicReader.Views.Main;
 
@@ -199,7 +199,7 @@ internal sealed partial class SettingPage : BasePage
     private void UpdateAbout()
     {
         string appName = StringResourceProvider.Instance.AppDisplayName;
-        AboutBuildVersionControl.Text = appName + " " + EnvironmentProvider.Instance.GetVersionName();
+        AboutBuildVersionControl.Text = appName + " " + EnvironmentProvider.GetVersionName();
 
         string author = "aicd0";
         string aboutCopyright = StringResourceProvider.Instance.AboutCopyright;

--- a/src/ComicReader/Views/Settings/SettingPageViewModel.cs
+++ b/src/ComicReader/Views/Settings/SettingPageViewModel.cs
@@ -10,11 +10,11 @@ using System.Text;
 using System.Threading.Tasks;
 
 using ComicReader.Common;
-using ComicReader.Common.AppEnvironment;
 using ComicReader.Common.Threading;
 using ComicReader.Data.Legacy;
 using ComicReader.Data.Models;
 using ComicReader.Data.Models.Comic;
+using ComicReader.SDK.Common.AppEnvironment;
 using ComicReader.SDK.Common.DebugTools;
 using ComicReader.SDK.Common.Storage;
 using ComicReader.SDK.Common.Threading;
@@ -598,7 +598,7 @@ public partial class SettingPageViewModel : INotifyPropertyChanged
 
     private static string GetLanguageDescriptionOfSystemLanguage(List<LanguageEntry> entries)
     {
-        string systemLanguage = EnvironmentProvider.Instance.GetCurrentSystemLanguage();
+        string systemLanguage = EnvironmentProvider.GetCurrentSystemLanguage();
         foreach (LanguageEntry entry in entries)
         {
             if (entry.Identifier == systemLanguage)


### PR DESCRIPTION
- Added `System.Management` package reference.
- Changed namespace from `ComicReader.Common.AppEnvironment` to `ComicReader.SDK.Common.AppEnvironment` across multiple files.
- Modified `DeviceInformationHelper` to be `internal` and improved return statement syntax.
- Enhanced `EnvironmentProvider` with a new private field and updated `Initialize` method to accept a string parameter.
- Refactored `GetEnvironmentTags` to be static and return a dictionary.
- Updated `SentryManager` to utilize new `EnvironmentProvider` methods.
- Changed access modifiers in `NativeMethods` and `NativeModels` from `internal` to `public`.
- Updated `WindowsHelper` to use `nint` instead of `IntPtr`.
- Introduced `Extensions` class with `SafeAppend` method for `StringBuilder`.
- Simplified static method calls in various files by replacing `EnvironmentProvider.Instance` with `EnvironmentProvider`.
- Updated `SettingPage` and `SettingPageViewModel` to use new static methods from `EnvironmentProvider`.
- Overall improvements in code readability and maintainability.